### PR TITLE
Setting jquery-rails gem version to 1.0.19 because it is known to work.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :assets do
   gem 'uglifier'
 end
 
-gem 'jquery-rails'
+gem 'jquery-rails', '=1.0.19'
 gem 'sprockets'
 #gem 'bson_ext', :platforms => :mri
 gem 'daemons'


### PR DESCRIPTION
The most recent version is causing Javascript errors to occur, maybe
because of incompatability with the older version of jquery-ui being
used.
