### PR TITLE
Use asc(:description) method instead of sort({description:1}) on queries

### DIFF
--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -17,7 +17,7 @@
       <th>Status</th>
     </tr>
     <% end %>
-    <% @queries.sort({description:1}).each do |query| %>
+    <% @queries.asc(:description).each do |query| %>
     <tr>
       <td><%= link_to query.title, query_path(query.id) %></td>
       <td><%= query.description %></td>


### PR DESCRIPTION
Use asc(:description) method instead of sort({description:1}) on queries in index.html.
Fixes test cases failing with "wrong number of arguments (1 for 0)" error on the sort method.
